### PR TITLE
Fix: 영화 상세정보 감독, 배우 순서 교체#12

### DIFF
--- a/cineffi/src/main/java/shinzo/cineffi/movie/MovieService.java
+++ b/cineffi/src/main/java/shinzo/cineffi/movie/MovieService.java
@@ -163,6 +163,17 @@ public class MovieService {
     }
 
     private List<CrewListDTO> getActorAndDorectorList(Long movieId) { //배우, 감독 가져오기
+        List<CrewListDTO> crewList = new ArrayList<>();
+
+        Movie movie = movieRepo.findById(movieId).orElse(null);
+        if (movie != null && movie.getDirector() != null) {
+            crewList.add(CrewListDTO.builder()
+                    .name(movie.getDirector().getName())
+                    .profile(encodeImage(movie.getDirector().getProfileImage()))
+                    .job("Director")
+                    .character("")
+                    .build());
+        }
 
         List<CrewListDTO> actors = actorMovieRepo.findByMovieId(movieId)
                 .stream()
@@ -174,16 +185,8 @@ public class MovieService {
                         .build())
                 .collect(Collectors.toList());
 
-        Movie movie = movieRepo.findById(movieId).orElse(null);
-        if (movie != null && movie.getDirector() != null) {
-            actors.add(CrewListDTO.builder()
-                    .name(movie.getDirector().getName())
-                    .profile(encodeImage(movie.getDirector().getProfileImage()))
-                    .job("Director")
-                    .character("")
-                    .build());
-        }
-        return actors;
+        crewList.addAll(actors);
+        return crewList;
     }
 
 


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * 제목 양식 -> feat : login-page 구현 #3 
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 영화 상세정보 불러오기에서 감독이 먼저나오고 이후 배우가 나오도록 수정 

