### PR TITLE
hotfix : getScore error in hot&latest Review API

### DIFF
--- a/cineffi/src/main/java/shinzo/cineffi/review/ReviewService.java
+++ b/cineffi/src/main/java/shinzo/cineffi/review/ReviewService.java
@@ -222,7 +222,7 @@ public class ReviewService {
                     .movieId(movie.getId())
                     .movieTitle(movie.getTitle())
                     .moviePoster(encodeImage(movie.getPoster()))
-                    .reviewScore(score.getScore())
+                    .reviewScore(score != null ? score.getScore() : null)
                     .reviewId(review.getId())
                     .reviewWriterId(user.getId())
                     .reviewWriterNickname(user.getNickname())


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * 제목 양식 -> feat : login-page 구현 #3 
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 에러나던 곳(리뷰모듈의 최신&인기평론 부분에서 평론의 평점이 있으면 담고, 없으면 null을담는 부분) 수정함
(Score가 null인 경우 그대로 null을 실어줘야하는데 score.getScore()를 시도했음)