### PR TITLE
hotfix: 인기평론 최소 좋아요 수 2개로 제한

### DIFF
--- a/cineffi/src/main/java/shinzo/cineffi/review/ReviewService.java
+++ b/cineffi/src/main/java/shinzo/cineffi/review/ReviewService.java
@@ -208,7 +208,8 @@ public class ReviewService {
     }
 
     public ReviewLookupListDTO sortReviewByHot(Pageable pageable, Long myUserId) {
-        return lookupReviewList(reviewRepository.findAllByIsDeleteFalseOrderByLikeNumDesc(pageable), myUserId);
+//        return lookupReviewList(reviewRepository.findAllByIsDeleteFalseOrderByLikeNumDesc(pageable), myUserId);
+        return lookupReviewList(reviewRepository.findAllByIsDeleteFalseAndLikeNumGreaterThanOrderByLikeNumDesc(pageable, 1), myUserId);
     }
 
     public ReviewLookupListDTO lookupReviewList(Page<Review> reviewPage, Long myUserId) {

--- a/cineffi/src/main/java/shinzo/cineffi/review/repository/ReviewRepository.java
+++ b/cineffi/src/main/java/shinzo/cineffi/review/repository/ReviewRepository.java
@@ -26,7 +26,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Page<Review> findAllByIsDeleteFalseOrderByCreatedAtDesc(Pageable pageable);
     Page<Review> findAllByIsDeleteFalseOrderByLikeNumDesc(Pageable pageable);
-
+    Page<Review> findAllByIsDeleteFalseAndLikeNumGreaterThanOrderByLikeNumDesc(Pageable pageable, int likenum);
     Optional<Object> findByIdAndUserId(Long reviewId, Long userId);
     Integer countByMovieAndIsDeleteFalse(Movie movie);
     Review findByMovieAndUserIdAndIsDeleteFalse(Movie movie, Long userId);


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * 제목 양식 -> feat : login-page 구현 #3 
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 인기 평론의 좋아요 수 최소 제한을 2개 이상으로 적용하였습니다.
