### PR TITLE
session 동기화 및 자잘한 문제 해결

### DIFF
--- a/cineffi/src/main/java/shinzo/cineffi/chat/CinEffiWebSocketHandler.java
+++ b/cineffi/src/main/java/shinzo/cineffi/chat/CinEffiWebSocketHandler.java
@@ -39,6 +39,7 @@ public class CinEffiWebSocketHandler extends TextWebSocketHandler {
             System.out.println("loginUserId = " + loginUserId);// [TMP]
             session.getAttributes().put("userId", loginUserId);
             chatController.chatSessionInit(loginUserId, session);
+
         } catch (CustomException e) {
             sendToSession(session, WebSocketMessage.builder().type("ERROR").sender("SERVER").data(ResponseDTO
                     .builder().isSuccess(false).message(e.getErrorMsg().getDetail()).build()).build());
@@ -76,7 +77,6 @@ public class CinEffiWebSocketHandler extends TextWebSocketHandler {
                 Long joinChatroomId = CinEffiUtils.getObject(payload, "data", Long.class);
                 sendToSession(session, chatController.chatroomJoin(nickname, joinChatroomId));
                 chatController.messageToChatroom(joinChatroomId, "SERVER:COME", nickname);
-                ChatController.getQueryLookers().remove(nickname);
             } else if (type.equals("SEND")) {
                 SendChatMessageDTO dto = CinEffiUtils.getObject(payload, "data", SendChatMessageDTO.class);
                 chatController.messageToChatroom(dto.getChatroomId(), nickname, dto.getMessage());
@@ -88,7 +88,8 @@ public class CinEffiWebSocketHandler extends TextWebSocketHandler {
             } else if (type.equals("BACKUP")) { // [TMP]이렇게 하면 안되지만 테스트를 위하여
                 chatController.tmpForBackupTest(); // [TMP]이 메서드도 지울거임
             } else if (type.equals("CLOSE")) { // [TMP]
-                chatController.tmpForChatroomClose(); // [TMP]
+                Long chatroomId = CinEffiUtils.getObject(payload, "data", Long.class);
+                chatController.tmpForChatroomClose(chatroomId); // [TMP]
             }
             else {
                 throw new CustomException(ErrorMsg.INVALID_TYPE_CALL);

--- a/cineffi/src/main/java/shinzo/cineffi/chat/repository/ChatroomRepository.java
+++ b/cineffi/src/main/java/shinzo/cineffi/chat/repository/ChatroomRepository.java
@@ -10,10 +10,10 @@ import shinzo.cineffi.domain.entity.chat.Chatroom;
 import java.util.List;
 
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
-    List<Chatroom> findAllByIsDeletedTrueOrderByIdDesc();
+    List<Chatroom> findAllByIsDeleteTrueOrderByIdDesc();
 
     @Modifying
-    @Transactional
     @Query("UPDATE Chatroom c SET c.isDelete = :isDelete WHERE c.id = :chatroomId")
     void updateIsDeleteById(@Param("chatroomId") Long chatroomId, @Param("isDelete") boolean isDelete);
+
 }

--- a/cineffi/src/main/java/shinzo/cineffi/domain/entity/chat/ChatMessage.java
+++ b/cineffi/src/main/java/shinzo/cineffi/domain/entity/chat/ChatMessage.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Entity
 @AllArgsConstructor
 @Builder
-
+@NoArgsConstructor
 public class ChatMessage {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "message_id")

--- a/cineffi/src/main/java/shinzo/cineffi/domain/entity/chat/Chatroom.java
+++ b/cineffi/src/main/java/shinzo/cineffi/domain/entity/chat/Chatroom.java
@@ -12,9 +12,7 @@ import shinzo.cineffi.domain.entity.BaseEntity;
 import shinzo.cineffi.domain.entity.user.User;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -43,13 +41,11 @@ public class Chatroom extends BaseEntity {
     @Column(columnDefinition = "TIMESTAMP(3) WITHOUT TIME ZONE")
     private LocalDateTime closedAt;
 
-    private boolean isDeleted;
-
     public RedisChatroom toRedisChatroom(List<String> tagList) {
         return RedisChatroom.builder()
                 .title(this.title)
                 .tags(tagList)
-                .memberNum(0) // 새로운 채팅방이 생성되면 최소한 한 명의 멤버가 있습니다.
+                .memberNum(0) // 새로운 채팅방이 생성되면 멤버가 0명입니다.
                 .createdAt(this.getCreatedAt().toString()) // 현재 시간으로 생성 시간 설정
                 .closedAt(this.getClosedAt().toString())// 처음에는 닫힌 시간이 없습니다.
                 .ownerId(owner.getId())//생성자

--- a/cineffi/src/main/java/shinzo/cineffi/domain/entity/chat/ChatroomTag.java
+++ b/cineffi/src/main/java/shinzo/cineffi/domain/entity/chat/ChatroomTag.java
@@ -1,12 +1,16 @@
 package shinzo.cineffi.domain.entity.chat;
 
 import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class ChatroomTag {
 


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * 제목 양식 -> feat : login-page 구현 #3 
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
1. 세션 중복시 기존 세션 밀어내기 구현
   - ` { "type" : "QUIT", "sender" : "SERVER", "data" : "외부 접속이 감지되어 현재 세션을 종료합니다."} `
2. chatlog 중 SERVER 메시지가 백업 안되던 것 해결 → `==` 를 `eqauls`로 변경
4. closed chatroomList가 출력 안되던 문제 해결
    - chatroom에 있던 `is_deleted` 필드 삭제하기 ⇒ 리포지토리 메서드 이름도 변경 (잘못적혀있었음)
5. [임시조치지만] CLOSE의 경우 `{ "type" : "CLOSE", "data" : 1}` 같은 방식으로 신청하도록 변경 
6. List를 보고있다가 JOIN 하는 경우 JOIN하는 당사자까지 LIST에서 받을 알림을 받는 문제 해결
    - queryLooker 세션 제거처리를 Handler단계에 있는걸 Controller로 내리고, 순서를 앞당겨 해결